### PR TITLE
Use built-in Jimeng and server-owned media credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,19 +3,21 @@ NEXT_PUBLIC_SITE_URL=https://ps.qiaomu.ai
 NEXT_PUBLIC_UMAMI_SRC=https://umami.qiaomu.ai/script.js
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=
 
-# AI_IMAGE_PROVIDER_ID: volc-seedream | hiapi | jimeng | custom
-AI_IMAGE_PROVIDER_ID=hiapi
+# AI_IMAGE_PROVIDER_ID: jimeng | volc-seedream | hiapi | custom
+AI_IMAGE_PROVIDER_ID=jimeng
 AI_IMAGE_API_KEY=
-AI_IMAGE_API_ENDPOINT=https://api.hiapi.ai/v1/images/generations
-AI_IMAGE_MODEL_ID=qwen-image-2.0
+AI_IMAGE_API_ENDPOINT=
+AI_IMAGE_MODEL_ID=
 AI_IMAGE_AUTH_HEADER=bearer
 AI_IMAGE_REQUEST_FORMAT=openai-image
 
 # Provider-specific alternatives are also supported.
 HIAPI_API_KEY=
+HIAPI_API_ENDPOINT=https://api.hiapi.ai/v1/images/generations
+HIAPI_MODEL_ID=qwen-image-2.0
 JIMENG_API_KEY=
 JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
-JIMENG_MODEL_ID=jimeng-4.5
+JIMENG_MODEL_ID=jimeng-5.0
 JIMENG_AUTH_HEADER=x-api-key
 JIMENG_REQUEST_FORMAT=jimeng
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm run dev
 应用支持在设置弹窗中切换 AI 生图服务商预设：
 
 - **HiAPI**：默认端点 `https://api.hiapi.ai/v1/images/generations`，默认模型 `qwen-image-2.0`
-- **即梦 API**：默认端点 `https://api.qiaomu.ai/jimeng-auth/v1/images/generations`，默认模型 `jimeng-4.5`
+- **即梦 API**：默认端点 `https://api.qiaomu.ai/jimeng-auth/v1/images/generations`，默认模型 `jimeng-5.0`，线上版由乔木服务端内置
 - **火山方舟 / Seedream**：保留现有 Seedream 兼容请求格式
 - **自定义兼容接口**：手动填写 Endpoint、Model ID、认证方式和请求格式
 
@@ -47,12 +47,12 @@ NEXT_PUBLIC_SITE_URL=https://ps.qiaomu.ai
 NEXT_PUBLIC_UMAMI_SRC=https://umami.qiaomu.ai/script.js
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=your_umami_website_id
 
-AI_IMAGE_PROVIDER_ID=hiapi
-AI_IMAGE_API_KEY=your_api_key
-AI_IMAGE_API_ENDPOINT=https://api.hiapi.ai/v1/images/generations
-AI_IMAGE_MODEL_ID=qwen-image-2.0
-AI_IMAGE_AUTH_HEADER=bearer
-AI_IMAGE_REQUEST_FORMAT=openai-image
+AI_IMAGE_PROVIDER_ID=jimeng
+JIMENG_API_KEY=your_server_side_jimeng_key
+JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
+JIMENG_MODEL_ID=jimeng-5.0
+JIMENG_AUTH_HEADER=x-api-key
+JIMENG_REQUEST_FORMAT=jimeng
 ```
 
 图片上传、AI 生成图转存、分享图和去背景结果会通过服务端七牛上传接口处理，需要配置：

--- a/app/components/home/SettingsDialog.tsx
+++ b/app/components/home/SettingsDialog.tsx
@@ -15,6 +15,7 @@ import {
   AIRequestFormat,
   DEFAULT_AI_PROVIDER_ID,
   getAIProviderPreset,
+  isBuiltInAIProvider,
   isAIAuthHeader,
   isAIProviderId,
   isAIRequestFormat,
@@ -28,6 +29,9 @@ interface SettingsDialogProps {
 // 检查是否已配置 API Key
 export function hasApiKeyConfigured(): boolean {
   if (typeof window === 'undefined') return false;
+  const providerId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId);
+  if (isBuiltInAIProvider(providerId)) return true;
+
   const apiKey = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiKey);
   return !!(apiKey && apiKey.trim());
 }
@@ -47,6 +51,7 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
   const [authHeader, setAuthHeader] = useState<AIAuthHeader>('bearer');
   const [requestFormat, setRequestFormat] = useState<AIRequestFormat>('seedream');
   const [removeBgApiKey, setRemoveBgApiKey] = useState('');
+  const isBuiltInProvider = isBuiltInAIProvider(providerId);
 
   useEffect(() => {
     if (isOpen) {
@@ -82,7 +87,7 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
   const handleSaveSettings = () => {
     localStorage.setItem(AI_PROVIDER_STORAGE_KEYS.providerId, providerId);
 
-    if (apiKey.trim()) {
+    if (!isBuiltInProvider && apiKey.trim()) {
       localStorage.setItem(AI_PROVIDER_STORAGE_KEYS.apiKey, apiKey);
     } else {
       localStorage.removeItem(AI_PROVIDER_STORAGE_KEYS.apiKey);
@@ -190,19 +195,22 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
                 value={modelId}
                 onChange={(e) => setModelId(e.target.value)}
                 placeholder={getAIProviderPreset(providerId).modelId || '输入模型 ID'}
+                disabled={isBuiltInProvider}
               />
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="api-key">API Key *</Label>
-              <Input
-                id="api-key"
-                type="password"
-                value={apiKey}
-                onChange={(e) => setApiKey(e.target.value)}
-                placeholder="输入你的 API Key"
-              />
-            </div>
+            {!isBuiltInProvider && (
+              <div className="space-y-2">
+                <Label htmlFor="api-key">API Key *</Label>
+                <Input
+                  id="api-key"
+                  type="password"
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                  placeholder="输入你的 API Key"
+                />
+              </div>
+            )}
 
             <div className="space-y-2">
               <Label htmlFor="api-endpoint">API 端点</Label>
@@ -212,6 +220,7 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
                 value={apiEndpoint}
                 onChange={(e) => setApiEndpoint(e.target.value)}
                 placeholder={getAIProviderPreset(providerId).endpoint || 'https://api.example.com/v1/images/generations'}
+                disabled={isBuiltInProvider}
               />
             </div>
 
@@ -223,6 +232,7 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
                   value={authHeader}
                   onChange={(e) => setAuthHeader(e.target.value as AIAuthHeader)}
                   className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none transition-[color,box-shadow] focus:border-gray-900 focus:ring-1 focus:ring-gray-900"
+                  disabled={isBuiltInProvider}
                 >
                   {AI_AUTH_HEADER_OPTIONS.map((option) => (
                     <option key={option.value} value={option.value}>
@@ -239,6 +249,7 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
                   value={requestFormat}
                   onChange={(e) => setRequestFormat(e.target.value as AIRequestFormat)}
                   className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none transition-[color,box-shadow] focus:border-gray-900 focus:ring-1 focus:ring-gray-900"
+                  disabled={isBuiltInProvider}
                 >
                   {AI_REQUEST_FORMAT_OPTIONS.map((option) => (
                     <option key={option.value} value={option.value}>

--- a/lib/ai-image-generator.ts
+++ b/lib/ai-image-generator.ts
@@ -1,4 +1,9 @@
-import { AI_PROVIDER_STORAGE_KEYS } from './ai-provider-config';
+import {
+  AI_PROVIDER_STORAGE_KEYS,
+  DEFAULT_AI_PROVIDER_ID,
+  isAIProviderId,
+  isBuiltInAIProvider,
+} from './ai-provider-config';
 
 // AI 生图服务
 export class AIImageGenerator {
@@ -8,8 +13,15 @@ export class AIImageGenerator {
   private getConfig() {
     if (typeof window === 'undefined') return {};
 
+    const savedProviderId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId);
+    const providerId = isAIProviderId(savedProviderId) ? savedProviderId : DEFAULT_AI_PROVIDER_ID;
+
+    if (isBuiltInAIProvider(providerId)) {
+      return { providerId };
+    }
+
     return {
-      providerId: localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId) || undefined,
+      providerId,
       apiKey: localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiKey) || undefined,
       apiEndpoint: localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiEndpoint) || undefined,
       modelId: localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.modelId) || undefined,

--- a/lib/ai-provider-config.ts
+++ b/lib/ai-provider-config.ts
@@ -11,6 +11,7 @@ export interface AIProviderPreset {
   authHeader: AIAuthHeader;
   requestFormat: AIRequestFormat;
   docsUrl?: string;
+  builtIn?: boolean;
 }
 
 export const AI_PROVIDER_STORAGE_KEYS = {
@@ -22,7 +23,7 @@ export const AI_PROVIDER_STORAGE_KEYS = {
   requestFormat: 'ai_request_format',
 } as const;
 
-export const DEFAULT_AI_PROVIDER_ID: AIProviderId = 'volc-seedream';
+export const DEFAULT_AI_PROVIDER_ID: AIProviderId = 'jimeng';
 
 export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
   {
@@ -48,11 +49,12 @@ export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
   {
     id: 'jimeng',
     label: '即梦 API',
-    description: '即梦兼容接口，支持 1K / 2K / 4K 与参考图改图。',
+    description: '乔木内置免费服务，默认使用 jimeng-5.0。',
     endpoint: 'https://api.qiaomu.ai/jimeng-auth/v1/images/generations',
-    modelId: 'jimeng-4.5',
+    modelId: 'jimeng-5.0',
     authHeader: 'x-api-key',
     requestFormat: 'jimeng',
+    builtIn: true,
   },
   {
     id: 'custom',
@@ -109,6 +111,11 @@ export function getAIProviderPreset(providerId?: string | null): AIProviderPrese
     AI_PROVIDER_PRESETS.find((preset) => preset.id === providerId) ||
     AI_PROVIDER_PRESETS.find((preset) => preset.id === DEFAULT_AI_PROVIDER_ID)!
   );
+}
+
+export function isBuiltInAIProvider(providerId?: string | null): boolean {
+  const preset = getAIProviderPreset(isAIProviderId(providerId) ? providerId : DEFAULT_AI_PROVIDER_ID);
+  return preset.builtIn === true;
 }
 
 export function isAIProviderId(value: string | null | undefined): value is AIProviderId {

--- a/lib/image-to-image-generator.ts
+++ b/lib/image-to-image-generator.ts
@@ -1,4 +1,9 @@
-import { AI_PROVIDER_STORAGE_KEYS } from './ai-provider-config';
+import {
+  AI_PROVIDER_STORAGE_KEYS,
+  DEFAULT_AI_PROVIDER_ID,
+  isAIProviderId,
+  isBuiltInAIProvider,
+} from './ai-provider-config';
 
 // 图片转图片生成器 - 通过Next.js API路由调用
 export class ImageToImageGenerator {
@@ -13,8 +18,15 @@ export class ImageToImageGenerator {
   private getConfig() {
     if (typeof window === 'undefined') return {};
 
+    const savedProviderId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId);
+    const providerId = isAIProviderId(savedProviderId) ? savedProviderId : DEFAULT_AI_PROVIDER_ID;
+
+    if (isBuiltInAIProvider(providerId)) {
+      return { providerId };
+    }
+
     return {
-      providerId: localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId) || undefined,
+      providerId,
       apiKey: localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiKey) || undefined,
       apiEndpoint: localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiEndpoint) || undefined,
       modelId: localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.modelId) || undefined,

--- a/lib/server/ai-provider.ts
+++ b/lib/server/ai-provider.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_AI_PROVIDER_ID,
   getAIProviderPreset,
   isAIAuthHeader,
+  isBuiltInAIProvider,
   isAIProviderId,
   isAIRequestFormat,
 } from '@/lib/ai-provider-config';
@@ -31,18 +32,21 @@ export function resolveAIProviderConfig(body: AIProviderRequestBody): ResolvedAI
   const providerId = resolveProviderId(body.providerId || process.env.AI_IMAGE_PROVIDER_ID);
   const preset = getAIProviderPreset(providerId);
   const providerEnv = getProviderEnvPrefix(providerId);
+  const useBuiltInProvider = isBuiltInAIProvider(providerId) && !clean(body.apiKey);
 
   const apiKey = clean(
-    body.apiKey ||
-      process.env[`${providerEnv}_API_KEY`] ||
-      process.env.AI_IMAGE_API_KEY ||
-      process.env.HIAPI_API_KEY ||
-      process.env.JIMENG_API_KEY ||
-      process.env.ARK_API_KEY
+    useBuiltInProvider
+      ? process.env[`${providerEnv}_API_KEY`]
+      : body.apiKey ||
+          process.env[`${providerEnv}_API_KEY`] ||
+          process.env.AI_IMAGE_API_KEY ||
+          process.env.HIAPI_API_KEY ||
+          process.env.JIMENG_API_KEY ||
+          process.env.ARK_API_KEY
   );
   const endpoint = normalizeImageEndpoint(
     clean(
-      body.apiEndpoint ||
+      (useBuiltInProvider ? '' : body.apiEndpoint) ||
         process.env[`${providerEnv}_API_ENDPOINT`] ||
         process.env[`${providerEnv}_BASE_URL`] ||
         process.env.AI_IMAGE_API_ENDPOINT ||
@@ -50,25 +54,28 @@ export function resolveAIProviderConfig(body: AIProviderRequestBody): ResolvedAI
     )
   );
   const modelId = clean(
-    body.modelId ||
+    (useBuiltInProvider ? '' : body.modelId) ||
       process.env[`${providerEnv}_MODEL_ID`] ||
       process.env.AI_IMAGE_MODEL_ID ||
       preset.modelId
   );
   const authHeader = resolveAuthHeader(
-    body.authHeader ||
+    (useBuiltInProvider ? '' : body.authHeader) ||
       process.env[`${providerEnv}_AUTH_HEADER`] ||
       process.env.AI_IMAGE_AUTH_HEADER ||
       preset.authHeader
   );
   const requestFormat = resolveRequestFormat(
-    body.requestFormat ||
+    (useBuiltInProvider ? '' : body.requestFormat) ||
       process.env[`${providerEnv}_REQUEST_FORMAT`] ||
       process.env.AI_IMAGE_REQUEST_FORMAT ||
       preset.requestFormat
   );
 
   if (!apiKey) {
+    if (useBuiltInProvider) {
+      throw new Error(`服务端未配置 ${providerEnv}_API_KEY，内置 ${preset.label} 暂不可用`);
+    }
     throw new Error('缺少 AI API Key，请在设置中填写，或配置服务端 AI_IMAGE_API_KEY');
   }
 


### PR DESCRIPTION
## Summary
- make Jimeng the default built-in image provider with `jimeng-5.0`
- prevent built-in Jimeng from using client-supplied endpoint/model/key overrides
- keep HiAPI, Seedream, and custom providers user-configurable
- document server-side Unsplash/Qiniu/Jimeng envs without committing secrets

## Verification
- npm run lint (0 errors, existing 46 warnings)
- npm run build
- server env smoke: Jimeng /v1/models 200, Unsplash search 200