### PR TITLE
支持即梦模型下拉选择

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ HIAPI_API_ENDPOINT=https://api.hiapi.ai/v1/images/generations
 HIAPI_MODEL_ID=qwen-image-2.0
 JIMENG_API_KEY=
 JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
+# Browser users can choose jimeng-5.0, jimeng-4.5, or jimeng from the settings dialog.
 JIMENG_MODEL_ID=jimeng-5.0
 JIMENG_AUTH_HEADER=x-api-key
 JIMENG_REQUEST_FORMAT=jimeng

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm run dev
 应用支持在设置弹窗中切换 AI 生图服务商预设：
 
 - **HiAPI**：默认端点 `https://api.hiapi.ai/v1/images/generations`，默认模型 `qwen-image-2.0`
-- **即梦 API**：默认端点 `https://api.qiaomu.ai/jimeng-auth/v1/images/generations`，默认模型 `jimeng-5.0`，线上版由乔木服务端内置
+- **即梦 API**：默认端点 `https://api.qiaomu.ai/jimeng-auth/v1/images/generations`，线上版由乔木服务端内置；模型可在设置里从 `jimeng-5.0`、`jimeng-4.5`、`jimeng` 下拉选择
 - **火山方舟 / Seedream**：保留现有 Seedream 兼容请求格式
 - **自定义兼容接口**：手动填写 Endpoint、Model ID、认证方式和请求格式
 

--- a/app/components/home/SettingsDialog.tsx
+++ b/app/components/home/SettingsDialog.tsx
@@ -52,6 +52,8 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
   const [requestFormat, setRequestFormat] = useState<AIRequestFormat>('seedream');
   const [removeBgApiKey, setRemoveBgApiKey] = useState('');
   const isBuiltInProvider = isBuiltInAIProvider(providerId);
+  const activeProvider = getAIProviderPreset(providerId);
+  const modelOptions = activeProvider.modelOptions || [];
 
   useEffect(() => {
     if (isOpen) {
@@ -60,7 +62,10 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
       const provider = getAIProviderPreset(nextProviderId);
       const savedApiKey = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiKey) || '';
       const savedEndpoint = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiEndpoint) || provider.endpoint;
-      const savedModelId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.modelId) || provider.modelId;
+      const storedModelId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.modelId);
+      const savedModelId = provider.modelOptions?.length
+        ? provider.modelOptions.find((option) => option.value === storedModelId)?.value || provider.modelId
+        : storedModelId || provider.modelId;
       const savedAuthHeader = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.authHeader);
       const savedRequestFormat = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.requestFormat);
       const savedRemoveBgApiKey = localStorage.getItem('removebg_api_key') || '';
@@ -189,14 +194,34 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
 
             <div className="space-y-2">
               <Label htmlFor="model-id">模型 ID *</Label>
-              <Input
-                id="model-id"
-                type="text"
-                value={modelId}
-                onChange={(e) => setModelId(e.target.value)}
-                placeholder={getAIProviderPreset(providerId).modelId || '输入模型 ID'}
-                disabled={isBuiltInProvider}
-              />
+              {modelOptions.length > 0 ? (
+                <select
+                  id="model-id"
+                  value={modelId || activeProvider.modelId}
+                  onChange={(e) => setModelId(e.target.value)}
+                  className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none transition-[color,box-shadow] focus:border-gray-900 focus:ring-1 focus:ring-gray-900"
+                >
+                  {modelOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <Input
+                  id="model-id"
+                  type="text"
+                  value={modelId}
+                  onChange={(e) => setModelId(e.target.value)}
+                  placeholder={activeProvider.modelId || '输入模型 ID'}
+                  disabled={isBuiltInProvider}
+                />
+              )}
+              {modelOptions.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  {modelOptions.find((option) => option.value === (modelId || activeProvider.modelId))?.description || activeProvider.description}
+                </p>
+              )}
             </div>
 
             {!isBuiltInProvider && (
@@ -219,7 +244,7 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
                 type="url"
                 value={apiEndpoint}
                 onChange={(e) => setApiEndpoint(e.target.value)}
-                placeholder={getAIProviderPreset(providerId).endpoint || 'https://api.example.com/v1/images/generations'}
+                placeholder={activeProvider.endpoint || 'https://api.example.com/v1/images/generations'}
                 disabled={isBuiltInProvider}
               />
             </div>

--- a/lib/ai-image-generator.ts
+++ b/lib/ai-image-generator.ts
@@ -2,6 +2,7 @@ import {
   AI_PROVIDER_STORAGE_KEYS,
   DEFAULT_AI_PROVIDER_ID,
   isAIProviderId,
+  isAIProviderModelId,
   isBuiltInAIProvider,
 } from './ai-provider-config';
 
@@ -17,7 +18,11 @@ export class AIImageGenerator {
     const providerId = isAIProviderId(savedProviderId) ? savedProviderId : DEFAULT_AI_PROVIDER_ID;
 
     if (isBuiltInAIProvider(providerId)) {
-      return { providerId };
+      const savedModelId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.modelId);
+      return {
+        providerId,
+        modelId: isAIProviderModelId(providerId, savedModelId) ? savedModelId || undefined : undefined,
+      };
     }
 
     return {

--- a/lib/ai-provider-config.ts
+++ b/lib/ai-provider-config.ts
@@ -2,12 +2,19 @@ export type AIProviderId = 'volc-seedream' | 'hiapi' | 'jimeng' | 'custom';
 export type AIAuthHeader = 'bearer' | 'x-api-key';
 export type AIRequestFormat = 'seedream' | 'openai-image' | 'jimeng';
 
+export interface AIModelOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
 export interface AIProviderPreset {
   id: AIProviderId;
   label: string;
   description: string;
   endpoint: string;
   modelId: string;
+  modelOptions?: AIModelOption[];
   authHeader: AIAuthHeader;
   requestFormat: AIRequestFormat;
   docsUrl?: string;
@@ -24,6 +31,24 @@ export const AI_PROVIDER_STORAGE_KEYS = {
 } as const;
 
 export const DEFAULT_AI_PROVIDER_ID: AIProviderId = 'jimeng';
+
+export const JIMENG_MODEL_OPTIONS: AIModelOption[] = [
+  {
+    value: 'jimeng-5.0',
+    label: '即梦 5.0',
+    description: '默认推荐，质量更高。',
+  },
+  {
+    value: 'jimeng-4.5',
+    label: '即梦 4.5',
+    description: '兼容旧版生成链路。',
+  },
+  {
+    value: 'jimeng',
+    label: '即梦默认',
+    description: '由乔木即梦代理选择默认模型。',
+  },
+];
 
 export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
   {
@@ -52,6 +77,7 @@ export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
     description: '乔木内置免费服务，默认使用 jimeng-5.0。',
     endpoint: 'https://api.qiaomu.ai/jimeng-auth/v1/images/generations',
     modelId: 'jimeng-5.0',
+    modelOptions: JIMENG_MODEL_OPTIONS,
     authHeader: 'x-api-key',
     requestFormat: 'jimeng',
     builtIn: true,
@@ -116,6 +142,12 @@ export function getAIProviderPreset(providerId?: string | null): AIProviderPrese
 export function isBuiltInAIProvider(providerId?: string | null): boolean {
   const preset = getAIProviderPreset(isAIProviderId(providerId) ? providerId : DEFAULT_AI_PROVIDER_ID);
   return preset.builtIn === true;
+}
+
+export function isAIProviderModelId(providerId: AIProviderId, modelId?: string | null): boolean {
+  const options = getAIProviderPreset(providerId).modelOptions;
+  if (!options?.length) return true;
+  return typeof modelId === 'string' && options.some((option) => option.value === modelId);
 }
 
 export function isAIProviderId(value: string | null | undefined): value is AIProviderId {

--- a/lib/image-to-image-generator.ts
+++ b/lib/image-to-image-generator.ts
@@ -2,6 +2,7 @@ import {
   AI_PROVIDER_STORAGE_KEYS,
   DEFAULT_AI_PROVIDER_ID,
   isAIProviderId,
+  isAIProviderModelId,
   isBuiltInAIProvider,
 } from './ai-provider-config';
 
@@ -22,7 +23,11 @@ export class ImageToImageGenerator {
     const providerId = isAIProviderId(savedProviderId) ? savedProviderId : DEFAULT_AI_PROVIDER_ID;
 
     if (isBuiltInAIProvider(providerId)) {
-      return { providerId };
+      const savedModelId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.modelId);
+      return {
+        providerId,
+        modelId: isAIProviderModelId(providerId, savedModelId) ? savedModelId || undefined : undefined,
+      };
     }
 
     return {

--- a/lib/server/ai-provider.ts
+++ b/lib/server/ai-provider.ts
@@ -7,6 +7,7 @@ import {
   isAIAuthHeader,
   isBuiltInAIProvider,
   isAIProviderId,
+  isAIProviderModelId,
   isAIRequestFormat,
 } from '@/lib/ai-provider-config';
 
@@ -53,8 +54,13 @@ export function resolveAIProviderConfig(body: AIProviderRequestBody): ResolvedAI
         preset.endpoint
     )
   );
+  const requestedModelId = clean(body.modelId);
+  if (useBuiltInProvider && requestedModelId && !isAIProviderModelId(providerId, requestedModelId)) {
+    throw new Error(`不支持的 ${preset.label} 模型: ${requestedModelId}`);
+  }
+
   const modelId = clean(
-    (useBuiltInProvider ? '' : body.modelId) ||
+    (useBuiltInProvider ? requestedModelId : body.modelId) ||
       process.env[`${providerEnv}_MODEL_ID`] ||
       process.env.AI_IMAGE_MODEL_ID ||
       preset.modelId


### PR DESCRIPTION
## Summary
- add supported Jimeng model options for `jimeng-5.0`, `jimeng-4.5`, and `jimeng`
- render the built-in Jimeng model setting as a dropdown instead of a disabled fixed input
- forward whitelisted selected Jimeng models from the browser and reject unsupported built-in model IDs on the server

## Verification
- npm run lint
- npm run build