### PR TITLE
补全即梦图片模型下拉列表

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ HIAPI_API_ENDPOINT=https://api.hiapi.ai/v1/images/generations
 HIAPI_MODEL_ID=qwen-image-2.0
 JIMENG_API_KEY=
 JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
-# Browser users can choose jimeng-5.0, jimeng-4.5, or jimeng from the settings dialog.
+# Browser users can choose jimeng-5.0, jimeng-4.6, jimeng-4.5, jimeng-4.1, jimeng-4.0, jimeng-3.1, or jimeng-3.0 from the settings dialog.
 JIMENG_MODEL_ID=jimeng-5.0
 JIMENG_AUTH_HEADER=x-api-key
 JIMENG_REQUEST_FORMAT=jimeng

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm run dev
 应用支持在设置弹窗中切换 AI 生图服务商预设：
 
 - **HiAPI**：默认端点 `https://api.hiapi.ai/v1/images/generations`，默认模型 `qwen-image-2.0`
-- **即梦 API**：默认端点 `https://api.qiaomu.ai/jimeng-auth/v1/images/generations`，线上版由乔木服务端内置；模型可在设置里从 `jimeng-5.0`、`jimeng-4.5`、`jimeng` 下拉选择
+- **即梦 API**：默认端点 `https://api.qiaomu.ai/jimeng-auth/v1/images/generations`，线上版由乔木服务端内置；模型可在设置里从 `jimeng-5.0`、`jimeng-4.6`、`jimeng-4.5`、`jimeng-4.1`、`jimeng-4.0`、`jimeng-3.1`、`jimeng-3.0` 下拉选择
 - **火山方舟 / Seedream**：保留现有 Seedream 兼容请求格式
 - **自定义兼容接口**：手动填写 Endpoint、Model ID、认证方式和请求格式
 

--- a/lib/ai-provider-config.ts
+++ b/lib/ai-provider-config.ts
@@ -36,17 +36,37 @@ export const JIMENG_MODEL_OPTIONS: AIModelOption[] = [
   {
     value: 'jimeng-5.0',
     label: '即梦 5.0',
-    description: '默认推荐，质量更高。',
+    description: '默认推荐，中国站和亚洲国际站可用。',
+  },
+  {
+    value: 'jimeng-4.6',
+    label: '即梦 4.6',
+    description: '中国站和亚洲国际站可用，支持智能比例。',
   },
   {
     value: 'jimeng-4.5',
     label: '即梦 4.5',
+    description: '即梦代理默认模型，兼容性最好。',
+  },
+  {
+    value: 'jimeng-4.1',
+    label: '即梦 4.1',
+    description: '兼容旧版生成链路，支持智能比例。',
+  },
+  {
+    value: 'jimeng-4.0',
+    label: '即梦 4.0',
     description: '兼容旧版生成链路。',
   },
   {
-    value: 'jimeng',
-    label: '即梦默认',
-    description: '由乔木即梦代理选择默认模型。',
+    value: 'jimeng-3.1',
+    label: '即梦 3.1',
+    description: '中国站可用的旧版模型。',
+  },
+  {
+    value: 'jimeng-3.0',
+    label: '即梦 3.0',
+    description: '旧版通用模型。',
   },
 ];
 


### PR DESCRIPTION
## Summary
- replace the generic `jimeng` dropdown entry with the explicit Jimeng image model list from `jimeng-api` v1.9.7
- add `jimeng-4.6`, `jimeng-4.1`, `jimeng-4.0`, `jimeng-3.1`, and `jimeng-3.0` to the built-in Jimeng whitelist
- update README and env example to document the full selectable image model set

## Notes
- `GET /v1/models` on the proxy is a hardcoded simplified list; the image generation route uses `IMAGE_MODEL_MAP` for actual supported image model IDs

## Verification
- npm run lint
- npm run build