### PR TITLE
Force HiAPI task format for legacy settings

### DIFF
--- a/app/components/home/SettingsDialog.tsx
+++ b/app/components/home/SettingsDialog.tsx
@@ -69,7 +69,8 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
       const nextProviderId = isAIProviderId(savedProviderId) ? savedProviderId : DEFAULT_AI_PROVIDER_ID;
       const provider = getAIProviderPreset(nextProviderId);
       const savedApiKey = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiKey) || '';
-      const savedEndpoint = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiEndpoint) || provider.endpoint;
+      const storedEndpoint = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiEndpoint) || provider.endpoint;
+      const savedEndpoint = nextProviderId === 'hiapi' ? normalizeHiapiEndpoint(storedEndpoint, provider.endpoint) : storedEndpoint;
       const storedModelId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.modelId);
       const savedModelId = provider.modelOptions?.length
         ? provider.modelOptions.find((option) => option.value === storedModelId)?.value || provider.modelId
@@ -83,7 +84,10 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
       setApiEndpoint(savedEndpoint);
       setModelId(savedModelId);
       setAuthHeader(isAIAuthHeader(savedAuthHeader) ? savedAuthHeader : provider.authHeader);
-      setRequestFormat(isAIRequestFormat(savedRequestFormat) ? savedRequestFormat : provider.requestFormat);
+      setRequestFormat(nextProviderId === 'hiapi'
+        ? 'hiapi-task'
+        : isAIRequestFormat(savedRequestFormat) ? savedRequestFormat : provider.requestFormat
+      );
       setRemoveBgApiKey(savedRemoveBgApiKey);
     }
   }, [isOpen]);
@@ -371,7 +375,7 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
                   value={requestFormat}
                   onChange={(e) => setRequestFormat(e.target.value as AIRequestFormat)}
                   className="h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-xs outline-none transition-[color,box-shadow] focus:border-gray-900 focus:ring-1 focus:ring-gray-900"
-                  disabled={isBuiltInProvider}
+                  disabled={isBuiltInProvider || providerId === 'hiapi'}
                 >
                   {AI_REQUEST_FORMAT_OPTIONS.map((option) => (
                     <option key={option.value} value={option.value}>
@@ -433,4 +437,18 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
       </DialogContent>
     </Dialog>
   );
+}
+
+function normalizeHiapiEndpoint(endpoint: string, fallback: string): string {
+  const trimmed = endpoint.trim().replace(/\/+$/, '');
+  if (!trimmed) return fallback;
+  if (trimmed.endsWith('/v1/tasks')) return trimmed;
+  if (trimmed.endsWith('/v1/images/generations')) {
+    return `${trimmed.replace(/\/v1\/images\/generations$/i, '')}/v1/tasks`;
+  }
+  if (trimmed.endsWith('/v1')) return `${trimmed}/tasks`;
+  if (trimmed === 'https://api.hiapi.ai' || trimmed === 'https://www.hiapi.ai') {
+    return `${trimmed}/v1/tasks`;
+  }
+  return trimmed;
 }

--- a/lib/server/ai-provider.ts
+++ b/lib/server/ai-provider.ts
@@ -72,12 +72,14 @@ export function resolveAIProviderConfig(body: AIProviderRequestBody): ResolvedAI
       process.env.AI_IMAGE_AUTH_HEADER ||
       preset.authHeader
   );
-  const requestFormat = resolveRequestFormat(
-    (useBuiltInProvider ? '' : body.requestFormat) ||
-      process.env[`${providerEnv}_REQUEST_FORMAT`] ||
-      process.env.AI_IMAGE_REQUEST_FORMAT ||
-      preset.requestFormat
-  );
+  const requestFormat = providerId === 'hiapi'
+    ? 'hiapi-task'
+    : resolveRequestFormat(
+        (useBuiltInProvider ? '' : body.requestFormat) ||
+          process.env[`${providerEnv}_REQUEST_FORMAT`] ||
+          process.env.AI_IMAGE_REQUEST_FORMAT ||
+          preset.requestFormat
+      );
 
   if (!apiKey) {
     if (useBuiltInProvider) {


### PR DESCRIPTION
## Summary
- Force server-side HiAPI requests to use the new hiapi-task format even when older browser settings still send openai-image
- Normalize saved HiAPI image endpoint values to /v1/tasks when opening settings
- Disable request-format editing for HiAPI so users do not accidentally switch back to the deprecated sync format

## Verification
- npm run lint
- npm run build