### PR TITLE
Fix AI image fetch resilience and server removebg fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ QINIU_DOMAIN=
 QINIU_UPLOAD_URL=https://upload.qiniup.com
 QINIU_STORAGE_PATH=xhs-cover
 
+# Optional server-side Remove.bg key. Browser users can still set their own key in settings.
+REMOVE_BG_API_KEY=
+
 # Optional image search proxy key.
 UNSPLASH_ACCESS_KEY=
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ QINIU_BUCKET=your_bucket
 QINIU_DOMAIN=https://your-cdn-domain.example.com
 ```
 
+Remove.bg 默认可由服务端统一内置，用户也可以在设置里填自己的 Key 覆盖：
+
+```bash
+REMOVE_BG_API_KEY=your_removebg_key
+```
+
 分享链接、公开模板和公开素材会优先使用 Vercel KV 兼容的 REST 环境变量：
 
 ```bash

--- a/app/api/ai-image/jobs/route.ts
+++ b/app/api/ai-image/jobs/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  AIImageJobRequestBody,
+  createAIImageJob,
+  getAIImageJob,
+  validateAIImageJobInput,
+} from '@/lib/server/ai-image-jobs';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as AIImageJobRequestBody;
+    const validationError = validateAIImageJobInput('text-to-image', body);
+
+    if (validationError) {
+      return NextResponse.json(
+        { error: validationError },
+        { status: 400 }
+      );
+    }
+
+    const job = createAIImageJob('text-to-image', body);
+    return NextResponse.json({ job }, { status: 202 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : '未知错误' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const jobId = request.nextUrl.searchParams.get('jobId')?.trim();
+
+  if (!jobId) {
+    return NextResponse.json(
+      { error: '缺少 jobId' },
+      { status: 400 }
+    );
+  }
+
+  const job = getAIImageJob(jobId);
+
+  if (!job) {
+    return NextResponse.json(
+      { error: '任务不存在或已过期' },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ job });
+}

--- a/app/api/image-to-image/jobs/route.ts
+++ b/app/api/image-to-image/jobs/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  AIImageJobRequestBody,
+  createAIImageJob,
+  getAIImageJob,
+  validateAIImageJobInput,
+} from '@/lib/server/ai-image-jobs';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json() as AIImageJobRequestBody;
+    const validationError = validateAIImageJobInput('image-to-image', body);
+
+    if (validationError) {
+      return NextResponse.json(
+        { error: validationError },
+        { status: 400 }
+      );
+    }
+
+    const job = createAIImageJob('image-to-image', body);
+    return NextResponse.json({ job }, { status: 202 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const jobId = request.nextUrl.searchParams.get('jobId')?.trim();
+
+  if (!jobId) {
+    return NextResponse.json(
+      { error: '缺少 jobId' },
+      { status: 400 }
+    );
+  }
+
+  const job = getAIImageJob(jobId);
+
+  if (!job) {
+    return NextResponse.json(
+      { error: '任务不存在或已过期' },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json({ job });
+}

--- a/app/api/remove-bg/route.ts
+++ b/app/api/remove-bg/route.ts
@@ -4,6 +4,8 @@ import { uploadBlobToQiniu } from '@/lib/server/qiniu';
 export async function POST(request: NextRequest) {
   try {
     const { imageUrl, apiKey } = await request.json();
+    const resolvedApiKey = clean(apiKey) || clean(process.env.REMOVE_BG_API_KEY) || clean(process.env.REMOVEBG_API_KEY);
+    const keySource = clean(apiKey) ? 'user' : 'server';
 
     if (!imageUrl) {
       return NextResponse.json(
@@ -12,14 +14,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    if (!apiKey) {
+    if (!resolvedApiKey) {
       return NextResponse.json(
-        { error: '缺少 Remove.bg API Key' },
-        { status: 400 }
+        { error: '服务端未配置 Remove.bg API Key，可在设置中填写自己的 Key 后重试' },
+        { status: 500 }
       );
     }
 
-    console.log('🎨 开始去除背景:', imageUrl);
+    console.log('🎨 开始去除背景:', { imageUrl, keySource });
 
     // 1. 调用 Remove.bg API
     const formData = new FormData();
@@ -29,7 +31,7 @@ export async function POST(request: NextRequest) {
     const removeBgResponse = await fetch('https://api.remove.bg/v1.0/removebg', {
       method: 'POST',
       headers: {
-        'X-API-Key': apiKey,
+        'X-API-Key': resolvedApiKey,
       },
       body: formData,
     });
@@ -78,4 +80,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+function clean(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
 }

--- a/app/components/home/SettingsDialog.tsx
+++ b/app/components/home/SettingsDialog.tsx
@@ -38,11 +38,9 @@ export function hasApiKeyConfigured(): boolean {
   return !!(apiKey && apiKey.trim());
 }
 
-// 检查是否已配置 Remove.bg API Key
+// Remove.bg 默认有服务端内置配置；用户可选填自己的 Key 覆盖。
 export function hasRemoveBgApiKeyConfigured(): boolean {
-  if (typeof window === 'undefined') return false;
-  const apiKey = localStorage.getItem('removebg_api_key');
-  return !!(apiKey && apiKey.trim());
+  return true;
 }
 
 export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
@@ -405,16 +403,16 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="removebg-api-key">API Key</Label>
+              <Label htmlFor="removebg-api-key">自有 API Key（可选）</Label>
               <Input
                 id="removebg-api-key"
                 type="password"
                 value={removeBgApiKey}
                 onChange={(e) => setRemoveBgApiKey(e.target.value)}
-                placeholder="输入你的 Remove.bg API Key"
+                placeholder="默认使用乔木内置服务"
               />
               <p className="text-xs text-muted-foreground">
-                用于一键去除图片背景功能
+                不填写时使用乔木服务端内置 Remove.bg；填写后会优先使用你自己的 Key。
               </p>
             </div>
           </div>

--- a/app/components/properties/ImagePropertiesPanel.tsx
+++ b/app/components/properties/ImagePropertiesPanel.tsx
@@ -5,7 +5,6 @@ import { Slider } from '@/components/ui/slider';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { FlipHorizontal, FlipVertical, Plus, Pencil, Trash2, X, ChevronDown, ChevronUp } from 'lucide-react';
-import { hasRemoveBgApiKeyConfigured } from '@/app/components/home/SettingsDialog';
 import { getAITransformPromptsManager, AITransformPrompt } from '@/lib/ai-transform-prompts';
 
 interface ImagePropertiesPanelProps {
@@ -40,7 +39,6 @@ export default function ImagePropertiesPanel({
   onSaturationChange,
   onRemoveBackground,
   onRemoveBackgroundLocal,
-  onOpenSettings,
   onAIImageTransform,
 }: ImagePropertiesPanelProps) {
   const [activeTab, setActiveTab] = useState('basic');
@@ -392,16 +390,6 @@ export default function ImagePropertiesPanel({
                 variant="outline"
                 size="sm"
                 onClick={async () => {
-                  // 检查是否配置了 API Key
-                  if (!hasRemoveBgApiKeyConfigured()) {
-                    if (onOpenSettings) {
-                      onOpenSettings();
-                    } else {
-                      alert('请先在设置中配置 Remove.bg API Key');
-                    }
-                    return;
-                  }
-
                   // 获取图片 URL
                   const imageUrl = selectedObject?._element?.src || selectedObject?.getSrc?.();
                   if (!imageUrl) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1129,11 +1129,7 @@ export default function Home() {
     if (!managerRef.current) return;
 
     try {
-      // 获取 API Key
-      const apiKey = localStorage.getItem('removebg_api_key');
-      if (!apiKey) {
-        throw new Error('请先在设置中配置 Remove.bg API Key');
-      }
+      const apiKey = localStorage.getItem('removebg_api_key')?.trim();
 
       console.log('🎨 开始去除背景...', imageUrl);
 
@@ -1152,7 +1148,7 @@ export default function Home() {
         },
         body: JSON.stringify({
           imageUrl,
-          apiKey,
+          apiKey: apiKey || undefined,
         }),
       })
         .then(async (response) => {

--- a/lib/ai-image-generator.ts
+++ b/lib/ai-image-generator.ts
@@ -5,10 +5,11 @@ import {
   isAIProviderModelId,
   isBuiltInAIProvider,
 } from './ai-provider-config';
+import { createAndPollAIImageJob } from './ai-image-job-client';
 
 // AI 生图服务
 export class AIImageGenerator {
-  private apiUrl = '/api/ai-image'; // 使用本地 API 路由，避免 CORS 问题
+  private apiUrl = '/api/ai-image/jobs'; // 使用后台任务路由，避免长连接中断
 
   // 从 localStorage 获取配置
   private getConfig() {
@@ -45,39 +46,16 @@ export class AIImageGenerator {
         hasCustomConfig: !!(config.apiKey || config.apiEndpoint || config.modelId)
       });
 
-      const response = await fetch(this.apiUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      const imageUrl = await createAndPollAIImageJob(
+        this.apiUrl,
+        {
           prompt: prompt,
           size: size,
           ...config, // 传递自定义配置
-        }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({ error: response.statusText }));
-        console.error('❌ 生成图片失败:', {
-          status: response.status,
-          statusText: response.statusText,
-          error: errorData,
-        });
-        throw new Error(errorData.error || `生成图片失败 (${response.status})`);
-      }
-
-      const result = await response.json();
-
-      // 提取图片 URL
-      if (result.data && result.data.length > 0 && result.data[0].url) {
-        const imageUrl = result.data[0].url;
-        console.log('✅ 图片生成成功:', imageUrl);
-        return imageUrl;
-      } else {
-        console.error('❌ 返回数据格式错误:', result);
-        throw new Error('返回数据中没有图片 URL');
-      }
+        }
+      );
+      console.log('✅ 图片生成成功:', imageUrl);
+      return imageUrl;
     } catch (error) {
       console.error('❌ AI 生图失败:', error);
       throw error;

--- a/lib/ai-image-job-client.ts
+++ b/lib/ai-image-job-client.ts
@@ -1,0 +1,122 @@
+interface AIImageJobResult {
+  url: string;
+  original_url?: string;
+  persisted?: boolean;
+}
+
+interface AIImageJob {
+  id: string;
+  status: 'queued' | 'running' | 'succeeded' | 'failed';
+  result?: AIImageJobResult;
+  error?: string;
+}
+
+interface AIImageJobResponse {
+  job?: AIImageJob;
+  error?: string;
+}
+
+const POLL_INTERVAL_MS = 2000;
+const JOB_TIMEOUT_MS = 240000;
+
+export async function createAndPollAIImageJob(
+  endpoint: string,
+  payload: Record<string, unknown>
+): Promise<string> {
+  const createResponse = await fetchJsonWithRetry<AIImageJobResponse>(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!createResponse.job?.id) {
+    throw new Error(createResponse.error || '创建生图任务失败');
+  }
+
+  const startedAt = Date.now();
+  const jobId = createResponse.job.id;
+
+  while (Date.now() - startedAt < JOB_TIMEOUT_MS) {
+    const pollResponse = await fetchJsonWithRetry<AIImageJobResponse>(
+      `${endpoint}?jobId=${encodeURIComponent(jobId)}`,
+      { method: 'GET' }
+    );
+    const job = pollResponse.job;
+
+    if (!job) {
+      throw new Error(pollResponse.error || '查询生图任务失败');
+    }
+
+    if (job.status === 'succeeded') {
+      if (!job.result?.url) {
+        throw new Error('返回数据中没有图片 URL');
+      }
+      return job.result.url;
+    }
+
+    if (job.status === 'failed') {
+      throw new Error(job.error || '生成图片失败');
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  throw new Error('生成图片超时，请稍后重试');
+}
+
+async function fetchJsonWithRetry<T>(
+  url: string,
+  init: RequestInit,
+  maxAttempts = 3
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const response = await fetch(url, init);
+      const data = await response.json().catch(() => null) as T | null;
+
+      if (!response.ok) {
+        const errorMessage = readErrorMessage(data) || `请求失败 (${response.status})`;
+        throw new Error(errorMessage);
+      }
+
+      if (!data) {
+        throw new Error('接口返回数据格式错误');
+      }
+
+      return data;
+    } catch (error) {
+      lastError = error;
+
+      if (!isNetworkFetchError(error) || attempt === maxAttempts) {
+        break;
+      }
+
+      await sleep(attempt * 1000);
+    }
+  }
+
+  if (isNetworkFetchError(lastError)) {
+    throw new Error('网络连接中断，已自动重试但仍未恢复，请稍后再试');
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('请求失败');
+}
+
+function readErrorMessage(data: unknown): string {
+  if (!data || typeof data !== 'object') return '';
+  const error = (data as { error?: unknown }).error;
+  return typeof error === 'string' ? error : '';
+}
+
+function isNetworkFetchError(error: unknown): boolean {
+  if (!(error instanceof TypeError)) return false;
+  return /fetch|network|load failed|failed to fetch/i.test(error.message);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/lib/image-to-image-generator.ts
+++ b/lib/image-to-image-generator.ts
@@ -5,14 +5,15 @@ import {
   isAIProviderModelId,
   isBuiltInAIProvider,
 } from './ai-provider-config';
+import { createAndPollAIImageJob } from './ai-image-job-client';
 
 // 图片转图片生成器 - 通过Next.js API路由调用
 export class ImageToImageGenerator {
   private endpoint: string;
 
   constructor() {
-    // 使用Next.js API路由,避免CORS问题
-    this.endpoint = '/api/image-to-image';
+    // 使用后台任务路由，避免长连接中断
+    this.endpoint = '/api/image-to-image/jobs';
   }
 
   // 从 localStorage 获取配置
@@ -54,32 +55,15 @@ export class ImageToImageGenerator {
   ): Promise<string> {
     try {
       const config = this.getConfig();
-      const response = await fetch(this.endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      return await createAndPollAIImageJob(
+        this.endpoint,
+        {
           prompt,
           image: imageUrl,
           size,
           ...config, // 传递自定义配置
-        }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || `API请求失败: ${response.status}`);
-      }
-
-      const data = await response.json();
-
-      // 检查返回数据格式
-      if (!data.data || !data.data[0] || !data.data[0].url) {
-        throw new Error('API返回数据格式错误');
-      }
-
-      return data.data[0].url;
+        }
+      );
     } catch (error) {
       console.error('❌ 图片转换失败:', error);
       throw error;
@@ -100,32 +84,15 @@ export class ImageToImageGenerator {
   ): Promise<string> {
     try {
       const config = this.getConfig();
-      const response = await fetch(this.endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
+      return await createAndPollAIImageJob(
+        this.endpoint,
+        {
           prompt,
           image: imageUrls,
           size,
           ...config, // 传递自定义配置
-        }),
-      });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.error || `API请求失败: ${response.status}`);
-      }
-
-      const data = await response.json();
-
-      // 检查返回数据格式
-      if (!data.data || !data.data[0] || !data.data[0].url) {
-        throw new Error('API返回数据格式错误');
-      }
-
-      return data.data[0].url;
+        }
+      );
     } catch (error) {
       console.error('❌ 图片转换失败:', error);
       throw error;

--- a/lib/server/ai-image-jobs.ts
+++ b/lib/server/ai-image-jobs.ts
@@ -1,0 +1,159 @@
+import 'server-only';
+
+import { randomUUID } from 'crypto';
+import {
+  AIProviderRequestBody,
+  buildImageGenerationPayload,
+  requestAIImageUrl,
+  resolveAIProviderConfig,
+} from '@/lib/server/ai-provider';
+import { persistRemoteImageToQiniu } from '@/lib/server/qiniu';
+
+export type AIImageJobKind = 'text-to-image' | 'image-to-image';
+export type AIImageJobStatus = 'queued' | 'running' | 'succeeded' | 'failed';
+
+export interface AIImageJobRequestBody extends AIProviderRequestBody {
+  prompt?: string;
+  size?: string;
+  image?: string | string[];
+}
+
+export interface AIImageJobResult {
+  url: string;
+  original_url: string;
+  persisted: boolean;
+}
+
+export interface PublicAIImageJob {
+  id: string;
+  kind: AIImageJobKind;
+  status: AIImageJobStatus;
+  createdAt: number;
+  updatedAt: number;
+  result?: AIImageJobResult;
+  error?: string;
+}
+
+const JOB_TTL_MS = 30 * 60 * 1000;
+const jobs = new Map<string, PublicAIImageJob>();
+
+export function createAIImageJob(
+  kind: AIImageJobKind,
+  body: AIImageJobRequestBody
+): PublicAIImageJob {
+  cleanupExpiredJobs();
+
+  const job: PublicAIImageJob = {
+    id: randomUUID(),
+    kind,
+    status: 'queued',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+
+  jobs.set(job.id, job);
+  void runAIImageJob(job.id, kind, body);
+
+  return cloneJob(job);
+}
+
+export function getAIImageJob(jobId: string): PublicAIImageJob | null {
+  cleanupExpiredJobs();
+  const job = jobs.get(jobId);
+  return job ? cloneJob(job) : null;
+}
+
+export function validateAIImageJobInput(
+  kind: AIImageJobKind,
+  body: AIImageJobRequestBody
+): string | null {
+  if (!body.prompt?.trim()) {
+    return kind === 'text-to-image' ? '缺少提示词' : 'Prompt is required';
+  }
+
+  if (kind === 'image-to-image' && !body.image) {
+    return 'Image is required';
+  }
+
+  return null;
+}
+
+async function runAIImageJob(
+  jobId: string,
+  kind: AIImageJobKind,
+  body: AIImageJobRequestBody
+): Promise<void> {
+  const job = jobs.get(jobId);
+  if (!job) return;
+
+  updateJob(job, { status: 'running' });
+
+  try {
+    const config = resolveAIProviderConfig(body);
+    const size = body.size || (kind === 'image-to-image' ? '2K' : '1024x1024');
+    const payload = buildImageGenerationPayload({
+      config,
+      prompt: body.prompt!.trim(),
+      image: body.image,
+      size,
+    });
+
+    console.log(kind === 'text-to-image' ? '开始调用 AI 生图任务' : '开始调用 AI 图生图任务', {
+      jobId,
+      provider: config.providerId,
+      endpoint: config.endpoint,
+      model: config.modelId,
+      requestFormat: config.requestFormat,
+      imageCount: Array.isArray(body.image) ? body.image.length : body.image ? 1 : 0,
+      size,
+    });
+
+    const originalUrl = await requestAIImageUrl(config, payload);
+    const persisted = await persistRemoteImageToQiniu(
+      originalUrl,
+      kind === 'text-to-image' ? 'ai-generated.jpg' : 'ai-transformed.jpg',
+      kind === 'text-to-image' ? 'ai-images' : 'xhs-cover'
+    );
+
+    updateJob(job, {
+      status: 'succeeded',
+      result: {
+        url: persisted.url,
+        original_url: persisted.originalUrl,
+        persisted: persisted.persisted,
+      },
+    });
+  } catch (error) {
+    console.error(kind === 'text-to-image' ? 'AI 生图任务失败:' : 'AI 图生图任务失败:', {
+      jobId,
+      error,
+    });
+    updateJob(job, {
+      status: 'failed',
+      error: error instanceof Error ? error.message : '未知错误',
+    });
+  }
+}
+
+function updateJob(
+  job: PublicAIImageJob,
+  updates: Partial<Pick<PublicAIImageJob, 'status' | 'result' | 'error'>>
+): void {
+  Object.assign(job, updates, { updatedAt: Date.now() });
+}
+
+function cleanupExpiredJobs(): void {
+  const now = Date.now();
+  for (const [jobId, job] of jobs) {
+    if (now - job.createdAt > JOB_TTL_MS) {
+      jobs.delete(jobId);
+    }
+  }
+}
+
+function cloneJob(job: PublicAIImageJob): PublicAIImageJob {
+  return {
+    ...job,
+    result: job.result ? { ...job.result } : undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- Add server-side Remove.bg fallback via REMOVE_BG_API_KEY/REMOVEBG_API_KEY while keeping user-provided keys as optional overrides.
- Replace long-running browser AI image POSTs with short job creation plus polling for text-to-image and image-to-image flows.
- Add client-side retry handling for transient fetch failures and document the new Remove.bg env var.

## Verification
- npm run lint
- npm run build
- Local smoke: /api/remove-bg returns a clear server config error when no Remove.bg key exists.
- Local smoke: /api/ai-image/jobs returns 202 quickly and polling reaches failed for an intentionally unreachable test endpoint.

## Note
- Existing ps.qiaomu.ai production env does not currently contain REMOVE_BG_API_KEY/REMOVEBG_API_KEY, so the code path is ready but the server key still needs to be supplied before built-in Remove.bg is active.