### PR TITLE
Harden built-in Jimeng access for open source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,11 @@
 # AI image provider defaults. The browser settings can override these per user.
-NEXT_PUBLIC_SITE_URL=https://ps.qiaomu.ai
+NEXT_PUBLIC_SITE_URL=http://localhost:3000
 NEXT_PUBLIC_UMAMI_SRC=https://umami.qiaomu.ai/script.js
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=
+NEXT_PUBLIC_ENABLE_BUILT_IN_JIMENG=false
 
 # AI_IMAGE_PROVIDER_ID: jimeng | volc-seedream | hiapi | custom
-AI_IMAGE_PROVIDER_ID=jimeng
+AI_IMAGE_PROVIDER_ID=hiapi
 AI_IMAGE_API_KEY=
 AI_IMAGE_API_ENDPOINT=
 AI_IMAGE_MODEL_ID=
@@ -19,10 +20,16 @@ HIAPI_AUTH_HEADER=bearer
 HIAPI_REQUEST_FORMAT=hiapi-task
 JIMENG_API_KEY=
 JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
+JIMENG_BUILT_IN_ENABLED=false
 # Browser users can choose jimeng-5.0, jimeng-4.6, jimeng-4.5, jimeng-4.1, jimeng-4.0, jimeng-3.1, or jimeng-3.0 from the settings dialog.
 JIMENG_MODEL_ID=jimeng-5.0
 JIMENG_AUTH_HEADER=x-api-key
 JIMENG_REQUEST_FORMAT=jimeng
+
+# Protect server-owned built-in image generation. Set allowed origins to your public site origin in production.
+AI_BUILTIN_IMAGE_RATE_LIMIT_PER_HOUR=20
+AI_BUILTIN_IMAGE_ALLOWED_ORIGINS=http://localhost:3000
+AI_BUILTIN_IMAGE_REQUIRE_ORIGIN=false
 
 # Qiniu is used to persist uploaded and generated images.
 QINIU_ACCESS_KEY=

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm run dev
 应用支持在设置弹窗中切换 AI 生图服务商预设：
 
 - **HiAPI**：默认端点 `https://api.hiapi.ai/v1/tasks`，默认模型 `gpt-image-2-beta`；模型下拉会从 HiAPI 模型接口刷新图片 task 模型，API Key 获取入口为 [https://www.hiapi.ai/zh/register?aff=NIWx](https://www.hiapi.ai/zh/register?aff=NIWx)
-- **即梦 API**：默认端点 `https://api.qiaomu.ai/jimeng-auth/v1/images/generations`，线上版由乔木服务端内置；模型可在设置里从 `jimeng-5.0`、`jimeng-4.6`、`jimeng-4.5`、`jimeng-4.1`、`jimeng-4.0`、`jimeng-3.1`、`jimeng-3.0` 下拉选择
+- **即梦 API**：线上 `ps.qiaomu.ai` 由乔木服务端内置；开源自部署不会获得乔木密钥，需要配置自己的服务端 Key，或切换到 HiAPI / Seedream / 自定义接口。模型可在设置里从 `jimeng-5.0`、`jimeng-4.6`、`jimeng-4.5`、`jimeng-4.1`、`jimeng-4.0`、`jimeng-3.1`、`jimeng-3.0` 下拉选择
 - **火山方舟 / Seedream**：保留现有 Seedream 兼容请求格式
 - **自定义兼容接口**：手动填写 Endpoint、Model ID、认证方式和请求格式
 
@@ -47,12 +47,24 @@ NEXT_PUBLIC_SITE_URL=https://ps.qiaomu.ai
 NEXT_PUBLIC_UMAMI_SRC=https://umami.qiaomu.ai/script.js
 NEXT_PUBLIC_UMAMI_WEBSITE_ID=your_umami_website_id
 
-AI_IMAGE_PROVIDER_ID=jimeng
+NEXT_PUBLIC_ENABLE_BUILT_IN_JIMENG=false
+
+AI_IMAGE_PROVIDER_ID=hiapi
 JIMENG_API_KEY=your_server_side_jimeng_key
 JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
+JIMENG_BUILT_IN_ENABLED=false
 JIMENG_MODEL_ID=jimeng-5.0
 JIMENG_AUTH_HEADER=x-api-key
 JIMENG_REQUEST_FORMAT=jimeng
+```
+
+如果你要在自己的部署里提供“服务端内置即梦”，需要同时显式开启前端入口和后端能力，并建议限制来源与频率：
+
+```bash
+NEXT_PUBLIC_ENABLE_BUILT_IN_JIMENG=true
+JIMENG_BUILT_IN_ENABLED=true
+AI_BUILTIN_IMAGE_ALLOWED_ORIGINS=https://your-domain.example.com
+AI_BUILTIN_IMAGE_RATE_LIMIT_PER_HOUR=20
 ```
 
 图片上传、AI 生成图转存、分享图和去背景结果会通过服务端七牛上传接口处理，需要配置：

--- a/app/api/ai-image/jobs/route.ts
+++ b/app/api/ai-image/jobs/route.ts
@@ -5,6 +5,7 @@ import {
   getAIImageJob,
   validateAIImageJobInput,
 } from '@/lib/server/ai-image-jobs';
+import { checkBuiltInAIRequestAccess } from '@/lib/server/ai-image-access';
 
 export const runtime = 'nodejs';
 
@@ -20,8 +21,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const access = checkBuiltInAIRequestAccess(request, body);
+    if (!access.allowed) {
+      return NextResponse.json(
+        { error: access.error || '内置 AI 生图服务暂不可用' },
+        { status: access.status || 403, headers: access.headers }
+      );
+    }
+
     const job = createAIImageJob('text-to-image', body);
-    return NextResponse.json({ job }, { status: 202 });
+    return NextResponse.json({ job }, { status: 202, headers: access.headers });
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : '未知错误' },

--- a/app/api/ai-image/route.ts
+++ b/app/api/ai-image/route.ts
@@ -5,6 +5,7 @@ import {
   resolveAIProviderConfig,
 } from '@/lib/server/ai-provider';
 import { persistRemoteImageToQiniu } from '@/lib/server/qiniu';
+import { checkBuiltInAIRequestAccess } from '@/lib/server/ai-image-access';
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,6 +16,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: '缺少提示词' },
         { status: 400 }
+      );
+    }
+
+    const access = checkBuiltInAIRequestAccess(request, body);
+    if (!access.allowed) {
+      return NextResponse.json(
+        { error: access.error || '内置 AI 生图服务暂不可用' },
+        { status: access.status || 403, headers: access.headers }
       );
     }
 
@@ -40,15 +49,18 @@ export async function POST(request: NextRequest) {
       'ai-images'
     );
 
-    return NextResponse.json({
-      data: [
-        {
-          url: persisted.url,
-          original_url: persisted.originalUrl,
-          persisted: persisted.persisted,
-        },
-      ],
-    });
+    return NextResponse.json(
+      {
+        data: [
+          {
+            url: persisted.url,
+            original_url: persisted.originalUrl,
+            persisted: persisted.persisted,
+          },
+        ],
+      },
+      { headers: access.headers }
+    );
   } catch (error) {
     console.error('AI 生图处理失败:', error);
     return NextResponse.json(

--- a/app/api/image-to-image/jobs/route.ts
+++ b/app/api/image-to-image/jobs/route.ts
@@ -5,6 +5,7 @@ import {
   getAIImageJob,
   validateAIImageJobInput,
 } from '@/lib/server/ai-image-jobs';
+import { checkBuiltInAIRequestAccess } from '@/lib/server/ai-image-access';
 
 export const runtime = 'nodejs';
 
@@ -20,8 +21,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const access = checkBuiltInAIRequestAccess(request, body);
+    if (!access.allowed) {
+      return NextResponse.json(
+        { error: access.error || '内置 AI 生图服务暂不可用' },
+        { status: access.status || 403, headers: access.headers }
+      );
+    }
+
     const job = createAIImageJob('image-to-image', body);
-    return NextResponse.json({ job }, { status: 202 });
+    return NextResponse.json({ job }, { status: 202, headers: access.headers });
   } catch (error) {
     return NextResponse.json(
       { error: error instanceof Error ? error.message : 'Internal server error' },

--- a/app/api/image-to-image/route.ts
+++ b/app/api/image-to-image/route.ts
@@ -5,6 +5,7 @@ import {
   resolveAIProviderConfig,
 } from '@/lib/server/ai-provider';
 import { persistRemoteImageToQiniu } from '@/lib/server/qiniu';
+import { checkBuiltInAIRequestAccess } from '@/lib/server/ai-image-access';
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,6 +23,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: 'Image is required' },
         { status: 400 }
+      );
+    }
+
+    const access = checkBuiltInAIRequestAccess(request, body);
+    if (!access.allowed) {
+      return NextResponse.json(
+        { error: access.error || '内置 AI 生图服务暂不可用' },
+        { status: access.status || 403, headers: access.headers }
       );
     }
 
@@ -49,15 +58,18 @@ export async function POST(request: NextRequest) {
       'xhs-cover'
     );
 
-    return NextResponse.json({
-      data: [
-        {
-          url: persisted.url,
-          original_url: persisted.originalUrl,
-          persisted: persisted.persisted,
-        },
-      ],
-    });
+    return NextResponse.json(
+      {
+        data: [
+          {
+            url: persisted.url,
+            original_url: persisted.originalUrl,
+            persisted: persisted.persisted,
+          },
+        ],
+      },
+      { headers: access.headers }
+    );
   } catch (error) {
     console.error('图片转换 API 错误:', error);
     return NextResponse.json(

--- a/app/components/home/SettingsDialog.tsx
+++ b/app/components/home/SettingsDialog.tsx
@@ -18,9 +18,10 @@ import {
   DEFAULT_AI_PROVIDER_ID,
   getAIProviderPreset,
   isBuiltInAIProvider,
+  isBuiltInAIProviderEnabled,
   isAIAuthHeader,
-  isAIProviderId,
   isAIRequestFormat,
+  resolveBrowserAIProviderId,
 } from '@/lib/ai-provider-config';
 
 interface SettingsDialogProps {
@@ -31,8 +32,8 @@ interface SettingsDialogProps {
 // 检查是否已配置 API Key
 export function hasApiKeyConfigured(): boolean {
   if (typeof window === 'undefined') return false;
-  const providerId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId);
-  if (isBuiltInAIProvider(providerId)) return true;
+  const providerId = resolveBrowserAIProviderId(localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId));
+  if (isBuiltInAIProvider(providerId)) return isBuiltInAIProviderEnabled(providerId);
 
   const apiKey = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiKey);
   return !!(apiKey && apiKey.trim());
@@ -64,7 +65,7 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
   useEffect(() => {
     if (isOpen) {
       const savedProviderId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId);
-      const nextProviderId = isAIProviderId(savedProviderId) ? savedProviderId : DEFAULT_AI_PROVIDER_ID;
+      const nextProviderId = resolveBrowserAIProviderId(savedProviderId);
       const provider = getAIProviderPreset(nextProviderId);
       const savedApiKey = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiKey) || '';
       const storedEndpoint = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.apiEndpoint) || provider.endpoint;
@@ -230,25 +231,29 @@ export default function SettingsDialog({ isOpen, onClose }: SettingsDialogProps)
             <div className="space-y-2">
               <Label>服务商预设</Label>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                {AI_PROVIDER_PRESETS.map((provider) => (
-                  <button
-                    key={provider.id}
-                    type="button"
-                    onClick={() => handleProviderChange(provider.id)}
-                    className={`rounded-md border px-3 py-2 text-left transition-colors ${
-                      providerId === provider.id
-                        ? 'border-gray-900 bg-gray-900 text-white'
-                        : 'border-gray-200 bg-white text-gray-700 hover:border-gray-900'
-                    }`}
-                  >
-                    <span className="block text-sm font-medium">{provider.label}</span>
-                    <span className={`mt-1 block text-xs leading-4 ${
-                      providerId === provider.id ? 'text-gray-200' : 'text-gray-500'
-                    }`}>
-                      {provider.description}
-                    </span>
-                  </button>
-                ))}
+                {AI_PROVIDER_PRESETS.map((provider) => {
+                  const isUnavailable = provider.builtIn && !isBuiltInAIProviderEnabled(provider.id);
+                  return (
+                    <button
+                      key={provider.id}
+                      type="button"
+                      onClick={() => !isUnavailable && handleProviderChange(provider.id)}
+                      disabled={isUnavailable}
+                      className={`rounded-md border px-3 py-2 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-55 ${
+                        providerId === provider.id
+                          ? 'border-gray-900 bg-gray-900 text-white'
+                          : 'border-gray-200 bg-white text-gray-700 hover:border-gray-900 disabled:hover:border-gray-200'
+                      }`}
+                    >
+                      <span className="block text-sm font-medium">{provider.label}</span>
+                      <span className={`mt-1 block text-xs leading-4 ${
+                        providerId === provider.id ? 'text-gray-200' : 'text-gray-500'
+                      }`}>
+                        {isUnavailable ? '服务端未启用，请使用自有 API 配置。' : provider.description}
+                      </span>
+                    </button>
+                  );
+                })}
               </div>
             </div>
 

--- a/lib/ai-image-generator.ts
+++ b/lib/ai-image-generator.ts
@@ -1,9 +1,8 @@
 import {
   AI_PROVIDER_STORAGE_KEYS,
-  DEFAULT_AI_PROVIDER_ID,
-  isAIProviderId,
   isAIProviderModelId,
   isBuiltInAIProvider,
+  resolveBrowserAIProviderId,
 } from './ai-provider-config';
 import { createAndPollAIImageJob } from './ai-image-job-client';
 
@@ -15,8 +14,7 @@ export class AIImageGenerator {
   private getConfig() {
     if (typeof window === 'undefined') return {};
 
-    const savedProviderId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId);
-    const providerId = isAIProviderId(savedProviderId) ? savedProviderId : DEFAULT_AI_PROVIDER_ID;
+    const providerId = resolveBrowserAIProviderId(localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId));
 
     if (isBuiltInAIProvider(providerId)) {
       const savedModelId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.modelId);

--- a/lib/ai-provider-config.ts
+++ b/lib/ai-provider-config.ts
@@ -32,7 +32,8 @@ export const AI_PROVIDER_STORAGE_KEYS = {
   requestFormat: 'ai_request_format',
 } as const;
 
-export const DEFAULT_AI_PROVIDER_ID: AIProviderId = 'jimeng';
+export const DEFAULT_AI_PROVIDER_ID: AIProviderId =
+  process.env.NEXT_PUBLIC_ENABLE_BUILT_IN_JIMENG === 'true' ? 'jimeng' : 'hiapi';
 
 export const JIMENG_MODEL_OPTIONS: AIModelOption[] = [
   {
@@ -152,7 +153,7 @@ export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
   {
     id: 'jimeng',
     label: '即梦 API',
-    description: '乔木内置免费服务，默认使用 jimeng-5.0。',
+    description: '服务端内置即梦能力，默认使用 jimeng-5.0。',
     endpoint: 'https://api.qiaomu.ai/jimeng-auth/v1/images/generations',
     modelId: 'jimeng-5.0',
     modelOptions: JIMENG_MODEL_OPTIONS,
@@ -225,6 +226,23 @@ export function getAIProviderPreset(providerId?: string | null): AIProviderPrese
 export function isBuiltInAIProvider(providerId?: string | null): boolean {
   const preset = getAIProviderPreset(isAIProviderId(providerId) ? providerId : DEFAULT_AI_PROVIDER_ID);
   return preset.builtIn === true;
+}
+
+export function isBuiltInAIProviderEnabled(providerId?: string | null): boolean {
+  const preset = getAIProviderPreset(isAIProviderId(providerId) ? providerId : DEFAULT_AI_PROVIDER_ID);
+  if (!preset.builtIn) return true;
+  if (preset.id === 'jimeng') {
+    return process.env.NEXT_PUBLIC_ENABLE_BUILT_IN_JIMENG === 'true';
+  }
+  return true;
+}
+
+export function resolveBrowserAIProviderId(value?: string | null): AIProviderId {
+  const providerId = isAIProviderId(value) ? value : DEFAULT_AI_PROVIDER_ID;
+  if (isBuiltInAIProvider(providerId) && !isBuiltInAIProviderEnabled(providerId)) {
+    return DEFAULT_AI_PROVIDER_ID;
+  }
+  return providerId;
 }
 
 export function isAIProviderModelId(providerId: AIProviderId, modelId?: string | null): boolean {

--- a/lib/image-to-image-generator.ts
+++ b/lib/image-to-image-generator.ts
@@ -1,9 +1,8 @@
 import {
   AI_PROVIDER_STORAGE_KEYS,
-  DEFAULT_AI_PROVIDER_ID,
-  isAIProviderId,
   isAIProviderModelId,
   isBuiltInAIProvider,
+  resolveBrowserAIProviderId,
 } from './ai-provider-config';
 import { createAndPollAIImageJob } from './ai-image-job-client';
 
@@ -20,8 +19,7 @@ export class ImageToImageGenerator {
   private getConfig() {
     if (typeof window === 'undefined') return {};
 
-    const savedProviderId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId);
-    const providerId = isAIProviderId(savedProviderId) ? savedProviderId : DEFAULT_AI_PROVIDER_ID;
+    const providerId = resolveBrowserAIProviderId(localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.providerId));
 
     if (isBuiltInAIProvider(providerId)) {
       const savedModelId = localStorage.getItem(AI_PROVIDER_STORAGE_KEYS.modelId);

--- a/lib/server/ai-image-access.ts
+++ b/lib/server/ai-image-access.ts
@@ -1,0 +1,172 @@
+import 'server-only';
+
+import { NextRequest } from 'next/server';
+import {
+  AIProviderRequestBody,
+  isServerBuiltInAIProviderEnabled,
+  isServerOwnedAIProviderRequest,
+  resolveAIProviderId,
+} from '@/lib/server/ai-provider';
+
+interface AccessResult {
+  allowed: boolean;
+  status?: number;
+  error?: string;
+  headers?: Record<string, string>;
+}
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const DEFAULT_WINDOW_MS = 60 * 60 * 1000;
+const DEFAULT_LIMIT = 20;
+const rateBuckets = new Map<string, RateLimitEntry>();
+
+export function checkBuiltInAIRequestAccess(
+  request: NextRequest,
+  body: AIProviderRequestBody
+): AccessResult {
+  if (!isServerOwnedAIProviderRequest(body)) {
+    return { allowed: true };
+  }
+
+  const providerId = resolveAIProviderId(body);
+  if (!isServerBuiltInAIProviderEnabled(providerId)) {
+    return {
+      allowed: false,
+      status: 403,
+      error: '服务端未启用内置即梦。开源自部署请配置自己的服务端 Key，或在设置中切换到 HiAPI / Seedream / 自定义接口。',
+    };
+  }
+
+  const originResult = checkOrigin(request);
+  if (!originResult.allowed) {
+    return originResult;
+  }
+
+  return checkRateLimit(request, body);
+}
+
+function checkOrigin(request: NextRequest): AccessResult {
+  const origin = normalizeOrigin(request.headers.get('origin'));
+  const requireOrigin = parseBoolean(process.env.AI_BUILTIN_IMAGE_REQUIRE_ORIGIN);
+
+  if (!origin) {
+    return requireOrigin
+      ? {
+          allowed: false,
+          status: 403,
+          error: '内置 AI 生图服务要求同源请求',
+        }
+      : { allowed: true };
+  }
+
+  const allowedOrigins = getAllowedOrigins();
+  if (allowedOrigins.has(origin)) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    status: 403,
+    error: '当前来源不允许调用内置 AI 生图服务',
+  };
+}
+
+function checkRateLimit(request: NextRequest, body: AIProviderRequestBody): AccessResult {
+  const limit = parsePositiveInt(process.env.AI_BUILTIN_IMAGE_RATE_LIMIT_PER_HOUR, DEFAULT_LIMIT);
+  if (limit <= 0) {
+    return { allowed: true };
+  }
+
+  const now = Date.now();
+  const providerId = resolveAIProviderId(body);
+  const ip = getClientIp(request);
+  const key = `${providerId}:${ip}`;
+  const existing = rateBuckets.get(key);
+  const entry = existing && existing.resetAt > now
+    ? existing
+    : { count: 0, resetAt: now + DEFAULT_WINDOW_MS };
+
+  cleanupExpiredBuckets(now);
+
+  if (entry.count >= limit) {
+    const retryAfter = Math.max(1, Math.ceil((entry.resetAt - now) / 1000));
+    return {
+      allowed: false,
+      status: 429,
+      error: `内置 AI 生图服务使用过于频繁，请 ${Math.ceil(retryAfter / 60)} 分钟后再试，或在设置中配置自己的 API。`,
+      headers: {
+        'Retry-After': String(retryAfter),
+        'X-RateLimit-Limit': String(limit),
+        'X-RateLimit-Remaining': '0',
+        'X-RateLimit-Reset': String(Math.ceil(entry.resetAt / 1000)),
+      },
+    };
+  }
+
+  entry.count += 1;
+  rateBuckets.set(key, entry);
+
+  return {
+    allowed: true,
+    headers: {
+      'X-RateLimit-Limit': String(limit),
+      'X-RateLimit-Remaining': String(Math.max(0, limit - entry.count)),
+      'X-RateLimit-Reset': String(Math.ceil(entry.resetAt / 1000)),
+    },
+  };
+}
+
+function getAllowedOrigins(): Set<string> {
+  const values = [
+    process.env.NEXT_PUBLIC_SITE_URL,
+    ...(process.env.AI_BUILTIN_IMAGE_ALLOWED_ORIGINS || '').split(','),
+  ];
+
+  if (process.env.NODE_ENV !== 'production') {
+    values.push('http://localhost:3000', 'http://127.0.0.1:3000');
+  }
+
+  return new Set(values.map((value) => normalizeOrigin(value)).filter(Boolean));
+}
+
+function getClientIp(request: NextRequest): string {
+  const cfIp = request.headers.get('cf-connecting-ip')?.trim();
+  if (cfIp) return cfIp;
+
+  const realIp = request.headers.get('x-real-ip')?.trim();
+  if (realIp) return realIp;
+
+  const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  return forwardedFor || 'unknown';
+}
+
+function normalizeOrigin(value?: string | null): string {
+  if (!value) return '';
+  try {
+    return new URL(value).origin;
+  } catch {
+    return '';
+  }
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function parseBoolean(value: string | undefined | null): boolean {
+  return ['1', 'true', 'yes', 'on'].includes((value || '').trim().toLowerCase());
+}
+
+function cleanupExpiredBuckets(now: number): void {
+  for (const [key, entry] of rateBuckets) {
+    if (entry.resetAt <= now) {
+      rateBuckets.delete(key);
+    }
+  }
+}

--- a/lib/server/ai-provider.ts
+++ b/lib/server/ai-provider.ts
@@ -30,10 +30,14 @@ export interface ResolvedAIProviderConfig {
 }
 
 export function resolveAIProviderConfig(body: AIProviderRequestBody): ResolvedAIProviderConfig {
-  const providerId = resolveProviderId(body.providerId || process.env.AI_IMAGE_PROVIDER_ID);
+  const providerId = resolveAIProviderId(body);
   const preset = getAIProviderPreset(providerId);
   const providerEnv = getProviderEnvPrefix(providerId);
   const useBuiltInProvider = isBuiltInAIProvider(providerId) && !clean(body.apiKey);
+
+  if (useBuiltInProvider && !isServerBuiltInAIProviderEnabled(providerId)) {
+    throw new Error(`服务端未启用内置 ${preset.label}。开源自部署请配置自己的服务端 Key，或在设置中切换到 HiAPI / Seedream / 自定义接口。`);
+  }
 
   const apiKey = clean(
     useBuiltInProvider
@@ -104,6 +108,26 @@ export function resolveAIProviderConfig(body: AIProviderRequestBody): ResolvedAI
     authHeader,
     requestFormat,
   };
+}
+
+export function resolveAIProviderId(body: AIProviderRequestBody): AIProviderId {
+  return resolveProviderId(body.providerId || process.env.AI_IMAGE_PROVIDER_ID);
+}
+
+export function isServerOwnedAIProviderRequest(body: AIProviderRequestBody): boolean {
+  const providerId = resolveAIProviderId(body);
+  return isBuiltInAIProvider(providerId) && !clean(body.apiKey);
+}
+
+export function isServerBuiltInAIProviderEnabled(providerId: AIProviderId): boolean {
+  if (providerId === 'jimeng') {
+    return parseBoolean(
+      process.env.JIMENG_BUILT_IN_ENABLED ||
+        process.env.AI_BUILTIN_JIMENG_ENABLED ||
+        process.env.QIAOMU_BUILT_IN_JIMENG_ENABLED
+    );
+  }
+  return true;
 }
 
 export function buildAIHeaders(config: ResolvedAIProviderConfig): Record<string, string> {
@@ -236,6 +260,10 @@ export function extractImageUrl(result: unknown): string {
 
 function clean(value: string | undefined | null): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function parseBoolean(value: string | undefined | null): boolean {
+  return ['1', 'true', 'yes', 'on'].includes(clean(value).toLowerCase());
 }
 
 function resolveProviderId(value: string | undefined): AIProviderId {


### PR DESCRIPTION
## Summary
- Make Qiaomu built-in Jimeng opt-in with explicit public and server-side env switches.
- Default open-source/self-host config to browser-configurable providers instead of Qiaomu built-in Jimeng.
- Add same-origin checks and per-IP fixed-window rate limiting to server-owned built-in image generation on both job and legacy routes.
- Document the open-source boundary and production guard env vars.

## Verification
- npm run lint
- npm run build
- Local smoke: built-in Jimeng without JIMENG_BUILT_IN_ENABLED returns 403 before creating a job.
- Local smoke: custom provider with user key still returns 202 and is not blocked by the built-in guard.
- Local smoke: built-in Jimeng with AI_BUILTIN_IMAGE_RATE_LIMIT_PER_HOUR=1 returns 202 then 429 for the same IP.
- Local smoke: disallowed Origin returns 403.