### PR TITLE
Default built-in Jimeng to 4.5

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ JIMENG_API_KEY=
 JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
 JIMENG_BUILT_IN_ENABLED=false
 # Browser users can choose jimeng-5.0, jimeng-4.6, jimeng-4.5, jimeng-4.1, jimeng-4.0, jimeng-3.1, or jimeng-3.0 from the settings dialog.
-JIMENG_MODEL_ID=jimeng-5.0
+JIMENG_MODEL_ID=jimeng-4.5
 JIMENG_AUTH_HEADER=x-api-key
 JIMENG_REQUEST_FORMAT=jimeng
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ AI_IMAGE_PROVIDER_ID=hiapi
 JIMENG_API_KEY=your_server_side_jimeng_key
 JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
 JIMENG_BUILT_IN_ENABLED=false
-JIMENG_MODEL_ID=jimeng-5.0
+JIMENG_MODEL_ID=jimeng-4.5
 JIMENG_AUTH_HEADER=x-api-key
 JIMENG_REQUEST_FORMAT=jimeng
 ```

--- a/lib/ai-provider-config.ts
+++ b/lib/ai-provider-config.ts
@@ -153,9 +153,9 @@ export const AI_PROVIDER_PRESETS: AIProviderPreset[] = [
   {
     id: 'jimeng',
     label: '即梦 API',
-    description: '服务端内置即梦能力，默认使用 jimeng-5.0。',
+    description: '服务端内置即梦能力，默认使用 jimeng-4.5。',
     endpoint: 'https://api.qiaomu.ai/jimeng-auth/v1/images/generations',
-    modelId: 'jimeng-5.0',
+    modelId: 'jimeng-4.5',
     modelOptions: JIMENG_MODEL_OPTIONS,
     authHeader: 'x-api-key',
     requestFormat: 'jimeng',


### PR DESCRIPTION
## Summary
- Change the built-in Jimeng preset default model from jimeng-5.0 to jimeng-4.5.
- Update README and .env.example to use jimeng-4.5 as the server-side Jimeng default.
- Keep the open-source template safe: built-in Jimeng remains disabled by default, and JIMENG_API_KEY is still blank.

## Verification
- npm run lint
- npm run build
- Staged secret scan found no real API keys.