### PR TITLE
Prepare Poster Studio for open source

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Report a reproducible Poster Studio bug
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: List the smallest steps that reproduce the issue.
+      placeholder: |
+        1. Open ...
+        2. Click ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: Browser, OS, deployment target, provider configuration.
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or logs
+      description: Do not paste API keys, tokens, cookies, or private URLs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Live demo
+    url: https://ps.qiaomu.ai
+    about: Try the hosted Qiaomu Poster Studio.
+  - name: Qiaomu AI tools directory
+    url: https://tuijian.qiaomu.ai
+    about: More tools and projects by Qiaomu.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest a focused improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow or pain point should this solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What should Poster Studio do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+-
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run build`
+- [ ] UI checked when relevant
+
+## Screenshots / Output
+
+Add screenshots, logs, or API responses when the change affects UI or runtime behavior.
+
+## Notes
+
+Mention any environment variables, provider keys, or deployment steps involved. Do not paste real secrets.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,20 @@
+# Code of Conduct
+
+We want Poster Studio to be a useful, respectful project for creators and developers.
+
+## Expected Behavior
+
+- Be kind and specific.
+- Assume good intent, but keep technical feedback direct.
+- Share reproducible steps, screenshots, logs, or patches when reporting bugs.
+- Respect privacy and never post other people's credentials, private content, or sensitive data.
+
+## Unacceptable Behavior
+
+- Harassment, personal attacks, slurs, or intimidation.
+- Publishing secrets, tokens, private URLs, or exploit details in public threads.
+- Spam, unrelated promotion, or repeated low-effort issue noise.
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments and may close issues or block users when behavior harms the project or community.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Poster Studio
+
+感谢你愿意改进乔木画布。这个项目面向真实内容创作场景，提交前请尽量让改动可验证、范围清晰。
+
+## 开发流程
+
+1. Fork 或新建分支。
+2. 安装依赖：
+
+   ```bash
+   npm install
+   ```
+
+3. 启动本地服务：
+
+   ```bash
+   npm run dev
+   ```
+
+4. 提交前至少运行：
+
+   ```bash
+   npm run lint
+   npm run build
+   ```
+
+## 提交 PR 前
+
+- 说明你解决了什么问题，最好附截图或操作路径。
+- 不要提交 `.env.local`、`.env.production`、`.data/`、`.next/`、`node_modules/`。
+- 不要在 issue、PR、日志或截图里暴露 API Key、Token、七牛密钥、Remove.bg Key、Unsplash Key。
+- 如果改动 AI provider、上传、分享、公开模板或 Vercel 部署，请说明验证过的环境变量组合。
+
+## Scope
+
+适合 PR 的方向：
+
+- 画布编辑体验、排版、导出、模板。
+- AI provider 兼容性与错误提示。
+- Vercel/self-host 文档。
+- 安全边界、限流、密钥处理。
+- UI 可访问性和移动端体验。
+
+较大的产品方向请先开 issue 讨论。

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 向阳乔木
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,64 +1,97 @@
 # 乔木画布 Poster Studio
 
-一个基于 Next.js 15 + Fabric.js 的在线海报设计工作台，当前重点支持小红书封面、知识卡片和社媒配图制作。
+> 面向小红书封面、知识卡片和社媒海报的在线设计工作台。打开即可排版、生成、去背景、导出。
+>
+> An online poster studio for Xiaohongshu covers, knowledge cards, and social graphics. Design, generate, remove backgrounds, and export in the browser.
 
-线上站点：[https://ps.qiaomu.ai](https://ps.qiaomu.ai)
+[![Live Demo](https://img.shields.io/badge/Live-ps.qiaomu.ai-111827)](https://ps.qiaomu.ai)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fjoeseesun%2Fposter-studio&project-name=poster-studio&repository-name=poster-studio)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-## ✨ 核心功能
+![乔木画布预览](public/templates/%E5%BC%95%E7%94%A8%E5%8D%A1%E7%89%87-1280%C3%97720.png)
 
-- **画布编辑**：1242×1660px 标准小红书封面尺寸
-- **多比例画布**：支持 3:4、1:1、4:3、16:9、21:9、9:16 等常用发布比例
-- **文字高亮**：支持荧光笔、下划线、边框三种高亮样式
-- **版本管理**：最多支持 5 个版本，可自由切换和复制
-- **导出功能**：下载 PNG 图片或复制到剪贴板
-- **AI 生图**：支持 HiAPI、即梦 API、火山方舟 / Seedream 和自定义兼容接口
-- **素材转存**：上传、生成图、去背景结果可通过服务端七牛配置转存
-- **自动保存**：每 2 秒自动保存当前版本
+**中文** | [English](#english)
 
-## 🚀 快速开始
+## 为什么值得用
 
-### 安装依赖
+很多内容创作者并不缺“图像生成”，缺的是一个能快速把标题、引用、图片、画布比例和导出流程串起来的轻量工具。乔木画布把这些日常步骤放在一个浏览器工作台里：
+
+- 适合小红书封面、公众号配图、知识卡片、课程海报、社媒图。
+- 不需要设计软件，直接在浏览器里编辑画布。
+- 本地自动保存，刷新后继续编辑。
+- 可接入自己的 HiAPI、火山方舟 / Seedream、自定义兼容接口，也可以在你自己的部署里开启服务端即梦。
+- 线上站点 [ps.qiaomu.ai](https://ps.qiaomu.ai) 使用乔木服务端内置即梦，默认模型 `jimeng-4.5`；开源模板不会包含或暴露乔木的 API Key。
+
+## 核心能力
+
+- **画布编辑**：文本、图片、形状、图层、样式、阴影、圆角、滤镜。
+- **多比例尺寸**：支持 3:4、1:1、4:3、16:9、21:9、9:16 等常用比例。
+- **文字高亮**：荧光笔、下划线、边框三种样式。
+- **版本管理**：最多 5 个版本，可复制当前版本继续改。
+- **AI 生图**：支持 HiAPI、即梦、火山方舟 / Seedream、自定义兼容接口。
+- **图生图 / 去背景**：支持参考图改写，Remove.bg 或本地背景移除。
+- **素材转存**：可通过服务端七牛配置转存上传图、生成图、去背景结果。
+- **分享与公开素材**：支持 Vercel KV；未配置时回退到本地文件存储。
+
+## 立即体验
+
+- 在线使用：[https://ps.qiaomu.ai](https://ps.qiaomu.ai)
+- 一键部署到 Vercel：
+
+  [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fjoeseesun%2Fposter-studio&project-name=poster-studio&repository-name=poster-studio)
+
+Vercel 一键部署默认是“无私有密钥基础版”：编辑、导出、本地自动保存可用；AI、七牛、Unsplash、Remove.bg、KV 等服务按需在 Vercel Project Settings 里配置环境变量。
+
+## 本地运行
 
 ```bash
 npm install
-```
-
-### 启动开发服务器
-
-```bash
 npm run dev
 ```
 
-打开浏览器访问 [http://localhost:3000](http://localhost:3000)
+打开 [http://localhost:3000](http://localhost:3000)。
 
-### 配置 AI 生图服务
-
-应用支持在设置弹窗中切换 AI 生图服务商预设：
-
-- **HiAPI**：默认端点 `https://api.hiapi.ai/v1/tasks`，默认模型 `gpt-image-2-beta`；模型下拉会从 HiAPI 模型接口刷新图片 task 模型，API Key 获取入口为 [https://www.hiapi.ai/zh/register?aff=NIWx](https://www.hiapi.ai/zh/register?aff=NIWx)
-- **即梦 API**：线上 `ps.qiaomu.ai` 由乔木服务端内置；开源自部署不会获得乔木密钥，需要配置自己的服务端 Key，或切换到 HiAPI / Seedream / 自定义接口。模型可在设置里从 `jimeng-5.0`、`jimeng-4.6`、`jimeng-4.5`、`jimeng-4.1`、`jimeng-4.0`、`jimeng-3.1`、`jimeng-3.0` 下拉选择
-- **火山方舟 / Seedream**：保留现有 Seedream 兼容请求格式
-- **自定义兼容接口**：手动填写 Endpoint、Model ID、认证方式和请求格式
-
-如果希望由服务端统一保存密钥，可复制 `.env.example` 为 `.env.local` 并填写：
+生产构建：
 
 ```bash
-NEXT_PUBLIC_SITE_URL=https://ps.qiaomu.ai
-NEXT_PUBLIC_UMAMI_SRC=https://umami.qiaomu.ai/script.js
-NEXT_PUBLIC_UMAMI_WEBSITE_ID=your_umami_website_id
+npm run build
+npm start
+```
 
+## 环境变量
+
+复制 `.env.example` 为 `.env.local`，按需填写。不要把 `.env.local`、`.env.production` 或任何真实 Key 提交到 Git。
+
+### 默认开源配置
+
+开源模板默认不启用乔木内置即梦：
+
+```bash
 NEXT_PUBLIC_ENABLE_BUILT_IN_JIMENG=false
-
 AI_IMAGE_PROVIDER_ID=hiapi
-JIMENG_API_KEY=your_server_side_jimeng_key
-JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
 JIMENG_BUILT_IN_ENABLED=false
+JIMENG_API_KEY=
+```
+
+用户可以在浏览器设置里填自己的 HiAPI / Seedream / 自定义接口 Key。线上 `ps.qiaomu.ai` 的乔木内置 Key 只存在于服务器环境变量，不会进入仓库，也不会下发到浏览器。
+
+### AI 生图
+
+```bash
+HIAPI_API_KEY=
+HIAPI_API_ENDPOINT=https://api.hiapi.ai/v1/tasks
+HIAPI_MODEL_ID=gpt-image-2-beta
+HIAPI_AUTH_HEADER=bearer
+HIAPI_REQUEST_FORMAT=hiapi-task
+
+JIMENG_API_KEY=
+JIMENG_API_ENDPOINT=https://api.qiaomu.ai/jimeng-auth/v1/images/generations
 JIMENG_MODEL_ID=jimeng-4.5
 JIMENG_AUTH_HEADER=x-api-key
 JIMENG_REQUEST_FORMAT=jimeng
 ```
 
-如果你要在自己的部署里提供“服务端内置即梦”，需要同时显式开启前端入口和后端能力，并建议限制来源与频率：
+如果你想在自己的部署里提供“服务端内置即梦”，需要显式开启，并建议限制来源与频率：
 
 ```bash
 NEXT_PUBLIC_ENABLE_BUILT_IN_JIMENG=true
@@ -67,85 +100,116 @@ AI_BUILTIN_IMAGE_ALLOWED_ORIGINS=https://your-domain.example.com
 AI_BUILTIN_IMAGE_RATE_LIMIT_PER_HOUR=20
 ```
 
-图片上传、AI 生成图转存、分享图和去背景结果会通过服务端七牛上传接口处理，需要配置：
+### 图片转存、搜索、去背景
 
 ```bash
-QINIU_ACCESS_KEY=your_qiniu_access_key
-QINIU_SECRET_KEY=your_qiniu_secret_key
-QINIU_BUCKET=your_bucket
-QINIU_DOMAIN=https://your-cdn-domain.example.com
+QINIU_ACCESS_KEY=
+QINIU_SECRET_KEY=
+QINIU_BUCKET=
+QINIU_DOMAIN=
+QINIU_UPLOAD_URL=https://upload.qiniup.com
+QINIU_STORAGE_PATH=xhs-cover
+
+UNSPLASH_ACCESS_KEY=
+REMOVE_BG_API_KEY=
 ```
 
-Remove.bg 默认可由服务端统一内置，用户也可以在设置里填自己的 Key 覆盖：
+### 分享 / 公开模板 / 公开素材
+
+Vercel 或其他 serverless 环境建议配置 Vercel KV 兼容变量，否则本地文件存储在无状态平台上不适合长期保存数据。
 
 ```bash
-REMOVE_BG_API_KEY=your_removebg_key
+KV_REST_API_URL=
+KV_REST_API_TOKEN=
+KV_REST_API_READ_ONLY_TOKEN=
+POSTER_STUDIO_DATA_DIR=
 ```
 
-分享链接、公开模板和公开素材会优先使用 Vercel KV 兼容的 REST 环境变量：
+## Vercel 部署说明
+
+1. 点击 README 顶部的 **Deploy with Vercel**。
+2. Vercel 会克隆本仓库到你的 GitHub/GitLab/Bitbucket，并自动识别 Next.js。
+3. 先部署基础版；需要服务端 AI、七牛、Unsplash、Remove.bg、KV 时，再到 Vercel Project Settings -> Environment Variables 填写对应变量。
+4. 如果修改了 `NEXT_PUBLIC_*` 变量，需要重新部署才会进入前端构建。
+
+## 数据与密钥边界
+
+- 浏览器侧：画布内容、版本、用户自填 API Key 默认保存在当前浏览器 localStorage。
+- 服务端侧：七牛、Unsplash、Remove.bg、服务端即梦 Key 只应放在部署平台环境变量。
+- 开源仓库：只保留 `.env.example` 占位符，不包含任何乔木生产密钥。
+- 线上乔木站点：`ps.qiaomu.ai` 使用服务端内置即梦，默认 `jimeng-4.5`，并对内置生图接口做来源校验和每 IP 限流。
+
+## 已验证
+
+最近一次发布验证：2026-06-18
+
+- `npm run lint` 通过，只有既有 warning。
+- `npm run build` 通过。
+- `https://ps.qiaomu.ai/` 返回 HTTP 200。
+- 线上内置即梦默认模型已验证为 `jimeng-4.5`。
+- 禁止来源调用内置即梦会返回 HTTP 403。
+
+## 贡献
+
+欢迎提交 issue 和 PR。开始前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。如果你发现安全问题，请不要在公开 issue 里贴密钥、日志或可利用细节，先看 [SECURITY.md](SECURITY.md)。
+
+## 关于向阳乔木
+
+这个项目由 [向阳乔木 / Joe](https://github.com/joeseesun) 维护。
+
+- 个人站：[qiaomu.ai](https://qiaomu.ai)
+- 博客：[blog.qiaomu.ai](https://blog.qiaomu.ai)
+- 乔木推荐：[tuijian.qiaomu.ai](https://tuijian.qiaomu.ai)
+- X：[ @vista8 ](https://x.com/vista8)
+- 微信公众号：向阳乔木推荐看
+
+## License
+
+[MIT](LICENSE)
+
+---
+
+<a name="english"></a>
+
+# Poster Studio
+
+Poster Studio is a browser-based design workspace for Xiaohongshu covers, quote cards, knowledge cards, and social graphics. It combines canvas editing, preset aspect ratios, AI image generation, background removal, export, and optional asset persistence.
+
+## Try It
+
+- Live demo: [https://ps.qiaomu.ai](https://ps.qiaomu.ai)
+- Deploy your own copy:
+
+  [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fjoeseesun%2Fposter-studio&project-name=poster-studio&repository-name=poster-studio)
+
+The one-click Vercel deploy works as a no-secret base edition. Canvas editing, export, and browser autosave work out of the box. Server-side AI, Qiniu, Unsplash, Remove.bg, and KV features are opt-in through environment variables.
+
+## Key Features
+
+- Fabric.js canvas editor for text, images, shapes, styles, filters, and layers.
+- Common social aspect ratios including 3:4, 1:1, 16:9, 21:9, and 9:16.
+- Version management and local autosave.
+- AI image generation through HiAPI, Jimeng, Seedream, or custom compatible endpoints.
+- Optional image-to-image, background removal, Qiniu persistence, and Vercel KV sharing.
+
+## Local Development
 
 ```bash
-KV_REST_API_URL=your_kv_rest_url
-KV_REST_API_TOKEN=your_kv_rest_token
-KV_REST_API_READ_ONLY_TOKEN=your_kv_read_only_token
+npm install
+npm run dev
 ```
 
-如果没有配置 KV，服务端会自动回退到本地文件存储。可通过 `POSTER_STUDIO_DATA_DIR` 指定持久化目录；未指定时使用项目根目录下的 `.data/`。
-
-### 构建生产版本
+Open [http://localhost:3000](http://localhost:3000).
 
 ```bash
 npm run build
 npm start
 ```
 
-## 📁 项目结构
+## Open-source Boundary
 
-```
-poster-studio/
-├── app/
-│   ├── components/          # React 组件
-│   │   ├── Header.tsx       # 头部组件
-│   │   ├── VersionBar.tsx   # 版本栏组件
-│   │   ├── Toolbar.tsx      # 工具栏组件
-│   │   └── PropertyPanel.tsx # 属性面板组件
-│   ├── page.tsx             # 主页面
-│   ├── layout.tsx           # 布局
-│   └── globals.css          # 全局样式
-├── lib/
-│   ├── types.ts             # 类型定义
-│   ├── canvas-manager.ts    # 画布管理器
-│   └── version-manager.ts   # 版本管理器
-└── package.json
-```
+This repository does not include Qiaomu's production API keys. The default `.env.example` keeps built-in Jimeng disabled and leaves all secret values blank. The hosted Qiaomu site uses server-side environment variables and request guards; self-hosted users must provide their own keys or use browser-configured providers.
 
-## 🛠️ 技术栈
+## License
 
-- **框架**：Next.js 15 (App Router)
-- **语言**：TypeScript
-- **画布**：Fabric.js 5.3
-- **样式**：Tailwind CSS
-- **字体**：思源黑体、思源宋体
-
-## 📖 使用说明
-
-1. **添加文本**：点击左侧工具栏的"添加文本"按钮
-2. **添加高亮文字**：在右侧属性面板输入文字，选择样式和颜色，点击"添加到画布"
-3. **编辑文本**：双击画布上的文字进行编辑
-4. **调整样式**：选中文字后，在右侧属性面板调整字号、字体、颜色
-5. **版本管理**：点击顶部版本栏切换版本，点击"+"复制当前版本
-6. **导出**：点击右上角"下载"或"复制"按钮
-
-## 🎨 高亮样式
-
-- **荧光笔**：半透明彩色背景
-- **下划线**：文字下方彩色线条
-- **边框**：文字周围彩色边框
-
-## 💾 数据存储
-
-所有版本数据自动保存在浏览器的 localStorage 中，无需担心数据丢失。
-
-## 📄 License
-
-MIT
+[MIT](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Version
+
+The `main` branch is the actively maintained version.
+
+## Reporting a Vulnerability
+
+请不要在公开 issue、PR、截图、日志里粘贴 API Key、Token、Cookie、七牛密钥、Remove.bg Key、Unsplash Key 或可被直接利用的漏洞细节。
+
+Preferred reporting paths:
+
+- Open a private GitHub security advisory if available.
+- If private advisories are not available, contact the maintainer through X: [@vista8](https://x.com/vista8), then share details privately.
+
+Please include:
+
+- A short description of the vulnerability.
+- Affected route, file, or workflow.
+- Steps to reproduce without exposing real secrets.
+- Suggested mitigation if you have one.
+
+We will prioritize issues that could expose secrets, bypass built-in provider guards, abuse server-owned AI generation, or write unexpected public data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "poster-studio",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@chinese-fonts/bxzlzt": "^3.0.0",
         "@chinese-fonts/dyh": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,24 @@
   "name": "poster-studio",
   "version": "0.1.0",
   "private": true,
+  "description": "Qiaomu Poster Studio: browser-based poster, cover, and social graphic editor for Xiaohongshu and knowledge cards.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joeseesun/poster-studio.git"
+  },
+  "homepage": "https://ps.qiaomu.ai",
+  "bugs": {
+    "url": "https://github.com/joeseesun/poster-studio/issues"
+  },
+  "keywords": [
+    "poster-studio",
+    "xiaohongshu",
+    "nextjs",
+    "fabricjs",
+    "ai-image",
+    "qiaomu"
+  ],
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary
- Rewrite README as a Chinese-first bilingual product page with live demo, local quick start, Vercel one-click deploy, and privacy boundaries.
- Add MIT license and community health files for external contributors.
- Update package metadata for the public GitHub surface.

## Verification
- npm run lint (passes with existing warnings)
- npm run build (passes with existing warnings)
- git diff --cached --check
- staged secret pattern scan

## Notes
- The open-source template does not include Qiaomu production secrets. ps.qiaomu.ai can keep using server-side environment variables for built-in Jimeng defaults.
- Vercel one-click deploy starts as a no-secret base deployment; optional providers are configured in Vercel Project Settings.